### PR TITLE
Support optional struct

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fcbuffer",
-  "description": "Serialization library geared towards immutable data storage such as blockchains.",
+  "name": "evt-fcbuffer",
+  "description": "Serialization library geared towards immutable data storage such as blockchains. (Branched from EOS)",
   "version": "2.2.2",
   "main": "lib/index.js",
   "files": [
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/EOSIO/fcbuffer.git"
+    "url": "git://github.com/everitoken/evt-fcbuffer.git"
   },
   "dependencies": {
     "bn.js": "^4.11.8",

--- a/src/fcbuffer.js
+++ b/src/fcbuffer.js
@@ -117,7 +117,7 @@ function create(definitions, types, config = types.config) {
     } else if (arrayType == null) {
       // AnyType
       const fieldStruct = structs[name]
-      if (fieldStruct) { return fieldStruct }
+      if (fieldStruct) { return typeatty.optional ? types.optional(fieldStruct) : fieldStruct }
 
       const type = types[name]
       if (!type) {


### PR DESCRIPTION
In the EOS Definitions: [schema - chain_types.json](https://github.com/EOSIO/eosjs-json/blob/master/schema/chain_types.json), a struct named `block_header` has an optional field `new_producers`.

But in the *fcbuffer.js*, only "Types" are wrapped by Optional Wrapper. I do not know if it is a bug or I misunderstand the definition.

Thanks.